### PR TITLE
Update system.cfg

### DIFF
--- a/data/system.cfg
+++ b/data/system.cfg
@@ -8,3 +8,7 @@ sys_PakPriority=0
 
 # Modification audio language
 #g_languageAudio=english
+
+sys_languages=english, polish
+g_language=polish
+g_languageAudio=english


### PR DESCRIPTION
Jeśli ma to być wersja PL to w system.cfg powinno już być odwołanie do języka polskiego . Po ostatnim patchu 3.11 nowy projekt tłumaczenia nie chciał działać z powodu tego braku. proponuję dodać tę wersję pliku do projektu.